### PR TITLE
Working git push without git binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .env*
 offline/
+vendor
+.bundle
+.irb-history

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem "foreman", "~> 0.77"
 gem "puma", "~> 2.11"
 gem "platform-api", "~> 0.2"
 gem "hashie", "~> 3.4"
-gem "git", "~> 1.2"
+gem 'rugged', git: 'git://github.com/libgit2/rugged.git', submodules: true
 
 gem "resque", "~> 1.25"
 gem "resque-lock", "~> 1.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,10 @@
+GIT
+  remote: git://github.com/libgit2/rugged.git
+  revision: d29af8812dda9c11905d23a8cafecc0bd39465e1
+  submodules: true
+  specs:
+    rugged (0.23.0b2)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -26,7 +33,6 @@ GEM
       multipart-post (>= 1.2, < 3)
     foreman (0.78.0)
       thor (~> 0.19.1)
-    git (1.2.9.1)
     hashie (3.4.1)
     heroics (0.0.14)
       erubis (~> 2.7.0)
@@ -118,7 +124,6 @@ DEPENDENCIES
   activerecord (~> 4.2)
   dotenv (~> 1.0)
   foreman (~> 0.77)
-  git (~> 1.2)
   hashie (~> 3.4)
   naught
   omniauth (~> 1.2)
@@ -131,5 +136,6 @@ DEPENDENCIES
   resque (~> 1.25)
   resque-lock (~> 1.1)
   rspec (~> 3.0)
+  rugged!
   sinatra (~> 1.4)
   sinatra-activerecord (~> 2.0)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# Branchinator
+
+
+## TODO
+
+* Key refresh/exchange for Heroku (& github?)
+* Bug: "Host key verification failed. fatal: Could not read from remote repository. Please make sure you have the correct access rights and the repository exists."
+* Notification on sucess to PR
+* Create Github ssh key (or use http?)

--- a/app/env.rb
+++ b/app/env.rb
@@ -24,30 +24,4 @@ module Branchinator
       reconnect: true
     )
   end
-
-  begin
-    available_keys = `ssh-add -l`.split("\n").map { |l|
-      l.match(/^\d* ([0-9a-f:]+) $/) ? $1 : nil
-    }.compact
-
-    if !available_keys.include?(ENV['DEPLOY_KEY_FINGERPRINT'])
-      puts "Private key fingerprint not present in ssh agent"
-
-      key_file = File.expand_path("~/.ssh/id_rsa")
-      if !File.exist?(key_file)
-        puts "Private key file not present"
-        raise "No private key variable to write" unless ENV['DEPLOY_KEY_PRIVATE']
-        FileUtils.mkdir_p(File.dirname(key_file))
-        open(key_file, "w") do |k|
-          k.puts "-----BEGIN RSA PRIVATE KEY-----"
-          k.puts ENV['DEPLOY_KEY_PRIVATE']
-          k.puts "-----END RSA PRIVATE KEY-----"
-        end
-        open("#{key_file}.pub", "w") do |k|
-          k.puts ENV['DEPLOY_KEY_PUBLIC']
-        end
-        puts "Private key written to #{key_file}[.pub]"
-      end
-    end
-  end
 end

--- a/script/console
+++ b/script/console
@@ -6,11 +6,9 @@ libs = []
 libs << "irb/completion"
 libs << File.expand_path(File.join(File.dirname(__FILE__),'env.rb'))
 
-command_line = []
-command_line << "irb"
+command_line = ["bundle exec irb -I lib -I app"]
 command_line << libs.inject("") { |acc, lib| acc + %( -r "#{lib}") }
 command_line << "--simple-prompt"
 command = command_line.join(" ")
 
-puts "Application console interface."
 exec command

--- a/script/env.rb
+++ b/script/env.rb
@@ -1,6 +1,15 @@
+require 'irb/ext/save-history'
+IRB.conf[:SAVE_HISTORY] = 100
+IRB.conf[:HISTORY_FILE] = ".irb-history"
+
 begin
   require "dotenv"
   Dotenv.load
 rescue LoadError
 end
-require_relative "../app/env"
+require "env"
+require "branchinator/jobs"
+
+include Branchinator
+
+puts "Branchinator Console… GO!"


### PR DESCRIPTION
- Use `rugged` as the git interface, has much more ruby-side control over credentials.
- Upgrades to the console app to make life easier
